### PR TITLE
solves the error referring to 'nativeElement' in angular 9

### DIFF
--- a/src/app/modules/ngx-kjua/ngx-kjua.component.ts
+++ b/src/app/modules/ngx-kjua/ngx-kjua.component.ts
@@ -183,13 +183,17 @@ export class NgxKjuaComponent implements OnInit, OnChanges {
   }
 
   renderCode() {
-    this.div.nativeElement.innerHTML = "";
-    this.div.nativeElement.appendChild(this.template);
+    setTimeout(() => {
+      this.div.nativeElement.innerHTML = "";
+      this.div.nativeElement.appendChild(this.template);
+    })
   }
 
   updateView() {
-    this.div.nativeElement.style.width = +this.size;
-    this.div.nativeElement.style.height = +this.size;
+    setTimeout(() => {
+      this.div.nativeElement.style.width = +this.size;
+      this.div.nativeElement.style.height = +this.size;
+    })
     if (this.renderAsync) {
       requestAnimationFrame(() => this.renderCode());
     } else {


### PR DESCRIPTION
Solves the error: "ERROR TypeError: Cannot read property 'nativeElement' of undefined" on Angular 9