### PR TITLE
Added build and publish automations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        required: true
+        type: number
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - name: Build on Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
+        with:
+          node-version: ${{ inputs.node-version }}
+      - run: npm ci --no-optional
+      - run: npm run build -- ngx-kjua --configuration=production
+      # Add all documentation files to the build
+      - run: cp *.md dist/ngx-kjua/
+      # Copy all assets to the build
+      - run: cp --parents src/assets/* dist/ngx-kjua
+      - run: cp LICENSE dist/ngx-kjua/
+      # TODO run tests when they are available
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
+        with:
+          name: ngx-kjua
+          path: dist/ngx-kjua/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-      - name: Build on Node.js ${{ matrix.node-version }}
+      - name: Build on Node.js ${{ inputs.node-version }}
         uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,13 +5,6 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node-version: [16.x, 17.x]
-    steps:
-      - name: Build for ${{ matrix.node-version }}
-        uses: ./.github/workflows/build.yml
-        with:
-          node-version: ${{ matrix.node-version }}
+    uses: ./.github/workflows/build.yml
+    with:
+      node-version: 16

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,17 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [16.x, 17.x]
+    steps:
+      - name: Build for ${{ matrix.node-version }}
+        uses: ./.github/workflows/build.yml
+        with:
+          node-version: ${{ matrix.node-version }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,35 @@
+# Reusable npm publish / release job
+on:
+  workflow_call:
+    inputs:
+      registry-url:
+        required: true
+        type: string
+      node-version:
+        required: true
+        type: number
+      release-tag:
+        required: false
+        type: string
+    secrets:
+      npm-token:
+        required: true
+
+jobs:
+  release-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869
+        with:
+          name: ngx-kjua
+          path: artifact/ngx-kjua/
+      - uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
+        with:
+          node-version: ${{ inputs.node-version }}
+          registry-url: ${{ inputs.registry-url }}
+      - run: npm ci --no-optional
+      - run: npm publish --access public ${{ inputs.release-tag }}
+        working-directory: artifact/ngx-kjua
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm-token }}

--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -1,0 +1,29 @@
+# Release the library to various npm repositories
+name: Release library
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build-release:
+    name: Build release
+    uses: ./.github/workflows/build.yml
+
+  publish-npm:
+    needs: build-release
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      registry-url: https://registry.npmjs.org/
+      node-version: 16
+    secrets:
+      npm-token: ${{ secrets.NPM_TOKEN }}
+
+  publish-gpr:
+    needs: build-release
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      registry-url: https://npm.pkg.github.com/
+      node-version: 16
+    secrets:
+      npm-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I added some automations for the building and publishing of this library.
@werthdavid for the automatic publishing to work you have to an action secret (Settings -> Secrets -> Actions) called `NPM_TOKEN` to this project. Within this secret a valid api token for the NPM registry has to be added. After the secret is added to the project the library is automatically published to the NPM registry when a release in Github is created.

# Changelog

- Added automatic build of the library on push events
- Added automatic publish to npm registries on Github release 