### PR TITLE
compatible with Angular 13

### DIFF
--- a/projects/ngx-kjua/src/lib/ngx-kjua.component.ts
+++ b/projects/ngx-kjua/src/lib/ngx-kjua.component.ts
@@ -11,7 +11,7 @@ import {
   SimpleChanges,
   ViewChild,
 } from "@angular/core";
-import * as kjua from "kjua-svg";
+import kjua from "kjua-svg";
 import { KjuaOptions } from "kjua-svg";
 import { KjuaEcLevel, KjuaMode, KjuaRender } from "./ngx-kjua.interface";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Solves the error: "ERROR TypeError: (kjua_svg__WEBPACK_IMPORTED_MODULE_0___namespace_cache || (intermediate value)(intermediate value)) is not a function" on Angular 13 https://github.com/werthdavid/ngx-kjua/issues/50#issuecomment-1042944051