### PR TITLE
refactor(imageAsCode, renderAsync): booleanAttribute

### DIFF
--- a/projects/ngx-kjua/src/lib/ngx-kjua.component.ts
+++ b/projects/ngx-kjua/src/lib/ngx-kjua.component.ts
@@ -9,6 +9,7 @@ import {
   Output,
   SimpleChanges,
   ViewChild,
+  booleanAttribute,
 } from "@angular/core";
 import { kjua } from "./kjua/index";
 import { KjuaOptions } from "./kjua/index.d";
@@ -87,7 +88,7 @@ export class NgxKjuaComponent implements AfterViewInit, OnChanges {
   }
 
   /**
-   * roundend corners in pc= 0..100
+   * rounded corners in pc= 0..100
    */
   @Input()
   rounded = 0;
@@ -115,7 +116,7 @@ export class NgxKjuaComponent implements AfterViewInit, OnChanges {
   mPosY: number | number[] = 50;
   @Input()
   image: null | undefined | HTMLImageElement | string = undefined;
-  @Input()
+  @Input({ transform: booleanAttribute })
   imageAsCode = false;
 
   /**
@@ -134,7 +135,7 @@ export class NgxKjuaComponent implements AfterViewInit, OnChanges {
    * If true, rendering is done inside "requestAnimationFrame"-call.
    * Use this if you want to generate more than one code (e.g. batch)
    */
-  @Input()
+  @Input({ transform: booleanAttribute })
   renderAsync = false;
 
   /**


### PR DESCRIPTION
`imageAsCode` and `renderAsync` will now be treated as `booleanAttribute`

Meaning, instead of writing 

```html
<ngx-kjua
  [imageAsCode]="true"
  [renderAsync]="true"
></ngx-kjua>
```
you shall do as follow
```html
<ngx-kjua
  imageAsCode
  renderAsync
></ngx-kjua>
```